### PR TITLE
Selecting fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,6 +133,11 @@ var async = require('async'),
     },
 
     buildSelectParameters = function (params) {
+
+        if (!params || !params.columns || !Array.isArray(params.columns)) {
+            return null;
+        }
+
         return params
             .columns
             .map(col => col.data)
@@ -175,8 +180,9 @@ var async = require('async'),
                             return cb(new Error('Some parameters are missing or in a wrong state. ' +
                             'Could be any of draw, start or length'));
                         }
-                        if (!findParameters || !sortParameters) {
-                            return cb(new Error('Invalid findParameters or sortParameters'));
+
+                        if (!findParameters || !sortParameters || !selectParameters) {
+                            return cb(new Error('Invalid findParameters or sortParameters or selectParameters'));
                         }
                         cb();
                     },

--- a/index.js
+++ b/index.js
@@ -132,6 +132,16 @@ var async = require('async'),
         return '-' + sortField;
     },
 
+    buildSelectParameters = function (params) {
+        return params
+            .columns
+            .map(col => col.data)
+            .reduce((selectParams, field) => {
+                selectParams[field] = 1;
+                return selectParams;
+            }, {});
+    },
+
     /**
      * Run wrapper function
      * Serves only to the Model parameter in the wrapped run function's scope
@@ -153,6 +163,7 @@ var async = require('async'),
                 length = Number(params.length),
                 findParameters = buildFindParameters(params),
                 sortParameters = buildSortParameters(params),
+                selectParameters = buildSelectParameters(params),
                 recordsTotal,
                 recordsFiltered;
 
@@ -190,6 +201,7 @@ var async = require('async'),
                     function runQuery (cb) {
                         Model
                             .find(findParameters)
+                            .select(selectParameters)
                             .limit(length)
                             .skip(start)
                             .sort(sortParameters)
@@ -234,8 +246,9 @@ var async = require('async'),
             run: run(Model),
             isNaNorUndefined: isNaNorUndefined,
             buildFindParameters: buildFindParameters,
-            buildSortParameters: buildSortParameters
-        }
+            buildSortParameters: buildSortParameters,
+            buildSelectParameters: buildSelectParameters
+        };
     };
 
 module.exports = datatablesQuery;

--- a/test.js
+++ b/test.js
@@ -60,15 +60,15 @@ describe('datatablesQuery tests', function () {
                 },
                 columns: [
                     {
-                        "data": "",
-                        "name": "",
-                        "searchable": "false"
+                        data: "",
+                        name: "",
+                        searchable: "false"
 
                     },
                     {
-                        "data": "name",
-                        "name": "",
-                        "searchable": "true"
+                        data: "name",
+                        name: "",
+                        searchable: "true"
                     }
                 ]
             };
@@ -92,9 +92,9 @@ describe('datatablesQuery tests', function () {
                             searchable: "true"
                         },
                         {
-                            "data": "email",
-                            "name": "",
-                            "searchable": "true"
+                            data: "email",
+                            name: "",
+                            searchable: "true"
                         }
                     ]
                 };
@@ -118,23 +118,23 @@ describe('datatablesQuery tests', function () {
 
         it('should build ascending sort parameters correctly', function (done) {
             var params = {
-                "columns": [
+                columns: [
                     {
-                        "data": "name",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "true"
+                        data: "name",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
                     },
                     {
-                        "data": "email",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "true"
+                        data: "email",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
                     }
                 ],
-                "order": [{
-                    "column": "0",
-                    "dir": "asc"
+                order: [{
+                    column: "0",
+                    dir: "asc"
                 }]
             };
 
@@ -144,23 +144,23 @@ describe('datatablesQuery tests', function () {
 
         it('should build descending sort parameters correctly', function (done) {
             var params = {
-                "columns": [
+                columns: [
                     {
-                        "data": "name",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "true"
+                        data: "name",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
                     },
                     {
-                        "data": "email",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "true"
+                        data: "email",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
                     }
                 ],
-                "order": [{
-                    "column": "1",
-                    "dir": "desc"
+                order: [{
+                    column: "1",
+                    dir: "desc"
                 }]
             };
 
@@ -170,23 +170,23 @@ describe('datatablesQuery tests', function () {
 
         it('should return null if a non orderable column is set as sort param', function (done) {
             var params = {
-                "columns": [
+                columns: [
                     {
-                        "data": "name",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "false"
+                        data: "name",
+                        name: "",
+                        searchable: "true",
+                        orderable: "false"
                     },
                     {
-                        "data": "email",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "true"
+                        data: "email",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
                     }
                 ],
-                "order": [{
-                    "column": "0",
-                    "dir": "desc"
+                order: [{
+                    column: "0",
+                    dir: "desc"
                 }]
             };
 
@@ -196,23 +196,23 @@ describe('datatablesQuery tests', function () {
 
         it('should return a correct search param if non searchable but orderable column is set as sort param', function (done) {
             var params = {
-                "columns": [
+                columns: [
                     {
-                        "data": "name",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "true"
+                        data: "name",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
                     },
                     {
-                        "data": "email",
-                        "name": "",
-                        "searchable": "false",
-                        "orderable": "true"
+                        data: "email",
+                        name: "",
+                        searchable: "false",
+                        orderable: "true"
                     }
                 ],
-                "order": [{
-                    "column": "1",
-                    "dir": "desc"
+                order: [{
+                    column: "1",
+                    dir: "desc"
                 }]
             };
 
@@ -222,23 +222,23 @@ describe('datatablesQuery tests', function () {
 
         it('should return null if an out of bound column is set as sort param', function (done) {
             var params = {
-                "columns": [
+                columns: [
                     {
-                        "data": "name",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "true"
+                        data: "name",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
                     },
                     {
-                        "data": "email",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "true"
+                        data: "email",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
                     }
                 ],
-                "order": [{
-                    "column": "2",
-                    "dir": "desc"
+                order: [{
+                    column: "2",
+                    dir: "desc"
                 }]
             };
 
@@ -248,18 +248,18 @@ describe('datatablesQuery tests', function () {
 
         it('should return null if params doesnot contain an order field', function (done) {
             var params = {
-                "columns": [
+                columns: [
                     {
-                        "data": "name",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "true"
+                        data: "name",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
                     },
                     {
-                        "data": "email",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "true"
+                        data: "email",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
                     },
 
                 ]
@@ -271,41 +271,41 @@ describe('datatablesQuery tests', function () {
 
         it('should return null if params.order.column is not provided or is not a number', function (done) {
             var paramsSet = [{
-                "columns": [
+                columns: [
                     {
-                        "data": "name",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "true"
+                        data: "name",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
                     },
                     {
-                        "data": "email",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "true"
+                        data: "email",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
                     }
                 ],
-                "order": [{
-                    "dir": "desc"
+                order: [{
+                    dir: "desc"
                 }]
             }, {
-                "columns": [
+                columns: [
                     {
-                        "data": "name",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "true"
+                        data: "name",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
                     },
                     {
-                        "data": "email",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "true"
+                        data: "email",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
                     }
                 ],
-                "order": [{
-                    "column": "abc",
-                    "dir": "desc"
+                order: [{
+                    column: "abc",
+                    dir: "desc"
                 }]
             }];
 
@@ -318,9 +318,9 @@ describe('datatablesQuery tests', function () {
 
         it('should return null if params.columns is not an array', function (done) {
             var params = {
-                "order": [{
-                    "column": "1",
-                    "dir": "desc"
+                order: [{
+                    column: "1",
+                    dir: "desc"
                 }]
             };
 
@@ -364,12 +364,12 @@ describe('datatablesQuery tests', function () {
                 error = sinon.spy();
 
             var params = {
-                "draw": "1",
-                "start": "10",
-                "length": "10",
-                "order": [{
-                    "column": "0",
-                    "dir": "desc"
+                draw: "1",
+                start: "10",
+                length: "10",
+                order: [{
+                    column: "0",
+                    dir: "desc"
                 }]
             };
 
@@ -402,26 +402,26 @@ describe('datatablesQuery tests', function () {
                 error = sinon.spy();
 
             var params = {
-                "draw": "1",
-                "start": "10",
-                "length": "10",
-                "columns": [
+                draw: "1",
+                start: "10",
+                length: "10",
+                columns: [
                     {
-                        "data": "name",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "false"
+                        data: "name",
+                        name: "",
+                        searchable: "true",
+                        orderable: "false"
                     },
                     {
-                        "data": "email",
-                        "name": "",
-                        "searchable": "true",
-                        "orderable": "true"
+                        data: "email",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
                     }
                 ],
-                "order": [{
-                    "column": "0",
-                    "dir": "desc"
+                order: [{
+                    column: "0",
+                    dir: "desc"
                 }]
             };
 

--- a/test.js
+++ b/test.js
@@ -99,8 +99,6 @@ describe('datatablesQuery tests', function () {
                     ]
                 };
 
-                //{ $or: [ { quantity: { $lt: 20 } }, { price: 10 } ] }
-
                 expect(query.buildFindParameters(multipleSearchableColumns))
                     .to.deep.equal({
                         $or: [{

--- a/test.js
+++ b/test.js
@@ -60,15 +60,15 @@ describe('datatablesQuery tests', function () {
                 },
                 columns: [
                     {
-                        data: "",
-                        name: "",
-                        searchable: "false"
+                        data: '',
+                        name: '',
+                        searchable: 'false'
 
                     },
                     {
-                        data: "name",
-                        name: "",
-                        searchable: "true"
+                        data: 'name',
+                        name: '',
+                        searchable: 'true'
                     }
                 ]
             };
@@ -87,14 +87,14 @@ describe('datatablesQuery tests', function () {
                     },
                     columns: [
                         {
-                            data: "name",
-                            name: "",
-                            searchable: "true"
+                            data: 'name',
+                            name: '',
+                            searchable: 'true'
                         },
                         {
-                            data: "email",
-                            name: "",
-                            searchable: "true"
+                            data: 'email',
+                            name: '',
+                            searchable: 'true'
                         }
                     ]
                 };
@@ -118,21 +118,21 @@ describe('datatablesQuery tests', function () {
             var params = {
                 columns: [
                     {
-                        data: "name",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
+                        data: 'name',
+                        name: '',
+                        searchable: 'true',
+                        orderable: 'true'
                     },
                     {
-                        data: "email",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
+                        data: 'email',
+                        name: '',
+                        searchable: 'true',
+                        orderable: 'true'
                     }
                 ],
                 order: [{
-                    column: "0",
-                    dir: "asc"
+                    column: '0',
+                    dir: 'asc'
                 }]
             };
 
@@ -144,21 +144,21 @@ describe('datatablesQuery tests', function () {
             var params = {
                 columns: [
                     {
-                        data: "name",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
+                        data: 'name',
+                        name: '',
+                        searchable: 'true',
+                        orderable: 'true'
                     },
                     {
-                        data: "email",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
+                        data: 'email',
+                        name: '',
+                        searchable: 'true',
+                        orderable: 'true'
                     }
                 ],
                 order: [{
-                    column: "1",
-                    dir: "desc"
+                    column: '1',
+                    dir: 'desc'
                 }]
             };
 
@@ -170,21 +170,21 @@ describe('datatablesQuery tests', function () {
             var params = {
                 columns: [
                     {
-                        data: "name",
-                        name: "",
-                        searchable: "true",
-                        orderable: "false"
+                        data: 'name',
+                        name: '',
+                        searchable: 'true',
+                        orderable: 'false'
                     },
                     {
-                        data: "email",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
+                        data: 'email',
+                        name: '',
+                        searchable: 'true',
+                        orderable: 'true'
                     }
                 ],
                 order: [{
-                    column: "0",
-                    dir: "desc"
+                    column: '0',
+                    dir: 'desc'
                 }]
             };
 
@@ -192,51 +192,52 @@ describe('datatablesQuery tests', function () {
             done();
         });
 
-        it('should return a correct search param if non searchable but orderable column is set as sort param', function (done) {
-            var params = {
-                columns: [
-                    {
-                        data: "name",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
-                    },
-                    {
-                        data: "email",
-                        name: "",
-                        searchable: "false",
-                        orderable: "true"
-                    }
-                ],
-                order: [{
-                    column: "1",
-                    dir: "desc"
-                }]
-            };
+        it('should return a correct search param if non searchable but orderable column is set as sort param',
+            function (done) {
+                var params = {
+                    columns: [
+                        {
+                            data: 'name',
+                            name: '',
+                            searchable: 'true',
+                            orderable: 'true'
+                        },
+                        {
+                            data: 'email',
+                            name: '',
+                            searchable: 'false',
+                            orderable: 'true'
+                        }
+                    ],
+                    order: [{
+                        column: '1',
+                        dir: 'desc'
+                    }]
+                };
 
-            expect(query.buildSortParameters(params)).to.equal('-email');
-            done();
-        });
+                expect(query.buildSortParameters(params)).to.equal('-email');
+                done();
+            });
 
         it('should return null if an out of bound column is set as sort param', function (done) {
             var params = {
                 columns: [
                     {
-                        data: "name",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
+                        data: 'name',
+                        name: '',
+                        searchable: 'true',
+                        orderable: 'true'
                     },
                     {
-                        data: "email",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
+                        data: 'email',
+                        name: '',
+                        searchable: 'true',
+                        orderable: 'true'
                     }
                 ],
                 order: [{
-                    column: "2",
-                    dir: "desc"
+                    column: '2',
+                    dir: 'desc'
                 }]
             };
 
@@ -248,18 +249,17 @@ describe('datatablesQuery tests', function () {
             var params = {
                 columns: [
                     {
-                        data: "name",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
+                        data: 'name',
+                        name: '',
+                        searchable: 'true',
+                        orderable: 'true'
                     },
                     {
-                        data: "email",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
-                    },
-
+                        data: 'email',
+                        name: '',
+                        searchable: 'true',
+                        orderable: 'true'
+                    }
                 ]
             };
 
@@ -271,39 +271,39 @@ describe('datatablesQuery tests', function () {
             var paramsSet = [{
                 columns: [
                     {
-                        data: "name",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
+                        data: 'name',
+                        name: '',
+                        searchable: 'true',
+                        orderable: 'true'
                     },
                     {
-                        data: "email",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
+                        data: 'email',
+                        name: '',
+                        searchable: 'true',
+                        orderable: 'true'
                     }
                 ],
                 order: [{
-                    dir: "desc"
+                    dir: 'desc'
                 }]
             }, {
                 columns: [
                     {
-                        data: "name",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
+                        data: 'name',
+                        name: '',
+                        searchable: 'true',
+                        orderable: 'true'
                     },
                     {
-                        data: "email",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
+                        data: 'email',
+                        name: '',
+                        searchable: 'true',
+                        orderable: 'true'
                     }
                 ],
                 order: [{
-                    column: "abc",
-                    dir: "desc"
+                    column: 'abc',
+                    dir: 'desc'
                 }]
             }];
 
@@ -317,8 +317,8 @@ describe('datatablesQuery tests', function () {
         it('should return null if params.columns is not an array', function (done) {
             var params = {
                 order: [{
-                    column: "1",
-                    dir: "desc"
+                    column: '1',
+                    dir: 'desc'
                 }]
             };
 
@@ -334,21 +334,21 @@ describe('datatablesQuery tests', function () {
             var params = {
                 columns: [
                     {
-                        data: "name",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
+                        data: 'name',
+                        name: '',
+                        searchable: 'true',
+                        orderable: 'true'
                     },
                     {
-                        data: "email",
-                        name: "",
-                        searchable: "false",
-                        orderable: "true"
+                        data: 'email',
+                        name: '',
+                        searchable: 'false',
+                        orderable: 'true'
                     }
                 ],
                 order: [{
-                    column: "1",
-                    dir: "desc"
+                    column: '1',
+                    dir: 'desc'
                 }]
             };
 
@@ -393,17 +393,17 @@ describe('datatablesQuery tests', function () {
         it('should reject promise if findParams is null', function (done) {
             var query = datatablesQuery({}),
                 success = sinon.spy(),
-                error = sinon.spy();
+                error = sinon.spy(),
 
-            var params = {
-                draw: "1",
-                start: "10",
-                length: "10",
-                order: [{
-                    column: "0",
-                    dir: "desc"
-                }]
-            };
+                params = {
+                    draw: '1',
+                    start: '10',
+                    length: '10',
+                    order: [{
+                        column: '0',
+                        dir: 'desc'
+                    }]
+                };
 
             expect(query.buildFindParameters(params)).to.equal(null);
 
@@ -431,31 +431,30 @@ describe('datatablesQuery tests', function () {
         it('should reject promise if sortParams is null', function (done) {
             var query = datatablesQuery({}),
                 success = sinon.spy(),
-                error = sinon.spy();
-
-            var params = {
-                draw: "1",
-                start: "10",
-                length: "10",
-                columns: [
-                    {
-                        data: "name",
-                        name: "",
-                        searchable: "true",
-                        orderable: "false"
-                    },
-                    {
-                        data: "email",
-                        name: "",
-                        searchable: "true",
-                        orderable: "true"
-                    }
-                ],
-                order: [{
-                    column: "0",
-                    dir: "desc"
-                }]
-            };
+                error = sinon.spy(),
+                params = {
+                    draw: '1',
+                    start: '10',
+                    length: '10',
+                    columns: [
+                        {
+                            data: 'name',
+                            name: '',
+                            searchable: 'true',
+                            orderable: 'false'
+                        },
+                        {
+                            data: 'email',
+                            name: '',
+                            searchable: 'true',
+                            orderable: 'true'
+                        }
+                    ],
+                    order: [{
+                        column: '0',
+                        dir: 'desc'
+                    }]
+                };
 
             expect(query.buildSortParameters(params)).to.equal(null);
 

--- a/test.js
+++ b/test.js
@@ -329,6 +329,40 @@ describe('datatablesQuery tests', function () {
         });
     });
 
+    describe('buildSelectParameters tests', function () {
+        var query = datatablesQuery({});
+
+        it('should include only and all columns passed in parameters in the select params', function (done) {
+            var params = {
+                columns: [
+                    {
+                        data: "name",
+                        name: "",
+                        searchable: "true",
+                        orderable: "true"
+                    },
+                    {
+                        data: "email",
+                        name: "",
+                        searchable: "false",
+                        orderable: "true"
+                    }
+                ],
+                order: [{
+                    column: "1",
+                    dir: "desc"
+                }]
+            };
+
+            expect(query.buildSelectParameters(params))
+                .to.deep.equal({
+                    email: 1,
+                    name: 1
+                });
+            done();
+        });
+    });
+
     describe('run tests', function () {
         it('should reject promise if params argument is lacking draw start or length', function (done) {
             var query = datatablesQuery({});


### PR DESCRIPTION
This PR changes the fields returned by the query to mongo. Previously, all fields were returned in the query. Now, only the columns passed as parameters will be returned in the query, plus the _id field.
Also, some lint fixes were made, so that linter is happy.
